### PR TITLE
CDPS-794: Introducing a named schema for prison person data

### DIFF
--- a/helm_deploy/hmpps-prison-person-api/values.yaml
+++ b/helm_deploy/hmpps-prison-person-api/values.yaml
@@ -41,14 +41,13 @@ generic-service:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
       PRISONER_SEARCH_CLIENT_ID: "PRISONER_SEARCH_CLIENT_ID"
       PRISONER_SEARCH_CLIENT_SECRET: "PRISONER_SEARCH_CLIENT_SECRET"
+      DATABASE_PRISONPERSON_PASSWORD: "DATABASE_PRISONPERSON_PASSWORD"
 
     rds-postgresql-instance-output:
       DATABASE_ENDPOINT: "rds_instance_endpoint"
       DATABASE_NAME: "database_name"
-      DATABASE_USERNAME: "database_username"
-      DATABASE_PASSWORD: "database_password"
-      SPRING_FLYWAY_USER: "database_username"
-      SPRING_FLYWAY_PASSWORD: "database_password"
+      DATABASE_SUPERUSER_USERNAME: "database_username"
+      DATABASE_SUPERUSER_PASSWORD: "database_password"
 
     hmpps-domain-events-topic:
       HMPPS_SQS_TOPICS_HMPPSEVENTTOPIC_ARN: "topic_arn"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/EventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/EventType.kt
@@ -5,5 +5,5 @@ enum class EventType(
   val telemetryEventName: String,
   val description: String,
 ) {
-  PHYSICAL_ATTRIBUTES_UPDATED("prison-person.physical-attributes.updated", "PrisonPersonPhysicalAttributesUpdate", "The physical attributes of a prisoner has been updated."),
+  PHYSICAL_ATTRIBUTES_UPDATED("prison-person.physical-attributes.updated", "PrisonPersonPhysicalAttributesUpdate", "The physical attributes of a prisoner have been updated."),
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,8 +17,6 @@ spring:
 
   datasource:
     url: jdbc:postgresql://localhost:5432/prison-person-data?sslmode=prefer
-    username: prison-person-data
-    password: prison-person-data
 
   jpa:
     show-sql: true
@@ -29,3 +27,10 @@ hmpps.sqs:
   topics:
     hmppseventtopic:
       arn: arn:aws:sns:eu-west-2:000000000000:hmpps-event-topic
+
+database:
+  superuser:
+    username: prison-person-data
+    password: prison-person-data
+  prisonperson:
+    password: prisonperson

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,11 +44,17 @@ spring:
 
   flyway:
     enabled: true
+    url: ${spring.datasource.url}
+    user: ${database.superuser.username}
+    password: ${database.superuser.password}
+    placeholders:
+      database_password: ${database.prisonperson.password}
+    schemas: prison_person
 
   datasource:
     url: 'jdbc:postgresql://${DATABASE_ENDPOINT}/${DATABASE_NAME}?sslmode=verify-full'
-    username: ${DATABASE_USERNAME}
-    password: ${DATABASE_PASSWORD}
+    username: prison_person
+    password: ${database.prisonperson.password}
     hikari:
       pool-name: PRISON_PERSON-DB-CP
       maximum-pool-size: 10

--- a/src/main/resources/db/migration/V1__create_role.sql
+++ b/src/main/resources/db/migration/V1__create_role.sql
@@ -1,0 +1,5 @@
+CREATE ROLE prison_person LOGIN PASSWORD '${database_password}';
+GRANT USAGE ON SCHEMA prison_person TO prison_person;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA prison_person TO prison_person;
+ALTER DEFAULT PRIVILEGES IN SCHEMA prison_person
+    GRANT USAGE, SELECT ON SEQUENCES TO prison_person;

--- a/src/main/resources/db/migration/V2__physical_attributes.sql
+++ b/src/main/resources/db/migration/V2__physical_attributes.sql
@@ -12,6 +12,8 @@ CREATE TABLE physical_attributes
     CONSTRAINT physical_attributes_pk PRIMARY KEY (prisoner_number)
 );
 
+GRANT SELECT, INSERT, UPDATE, DELETE ON physical_attributes TO prison_person;
+
 COMMENT ON TABLE physical_attributes IS 'The height and weight of a prisoner';
 COMMENT ON COLUMN physical_attributes.prisoner_number IS 'Primary key - the identifier of a prisoner (also often called prison number, NOMS number, offender number...)';
 COMMENT ON COLUMN physical_attributes.height_cm IS 'Prisoner height, in centimetres';
@@ -40,24 +42,9 @@ CREATE TABLE physical_attributes_history
     CONSTRAINT physical_attributes_history_prisoner_number_fk FOREIGN KEY (prisoner_number) REFERENCES physical_attributes(prisoner_number)
 );
 
+GRANT SELECT, INSERT, UPDATE, DELETE ON physical_attributes_history TO prison_person;
+
 COMMENT ON TABLE physical_attributes_history IS 'The history of the height and weight of a prisoner';
 COMMENT ON COLUMN physical_attributes_history.applies_from IS 'The timestamp from which these physical attributes were true of the prisoner. This is potentially different to the created_at timestamp to accommodate for the possibility that this was retroactively recorded data.';
 COMMENT ON COLUMN physical_attributes_history.applies_to IS 'The timestamp at which these physical attributes were no longer true of the prisoner. This should be populated for an old history record whenever a new history record is created.';
 
---
-
-CREATE TABLE physical_attributes_migration
-(
-    physical_attributes_migration_id    BIGSERIAL                   NOT NULL,
-    physical_attributes_history_id      BIGSERIAL                   NOT NULL,
-    offender_book_id                    BIGINT                      NOT NULL,
-    attribute_seq                       INT                         NOT NULL,
-    migrated_at                         TIMESTAMP WITH TIME ZONE    NOT NULL,
-
-    CONSTRAINT physical_attributes_migration_pk PRIMARY KEY (physical_attributes_migration_id),
-    CONSTRAINT physical_attributes_migration_history_id_fk FOREIGN KEY (physical_attributes_history_id) REFERENCES physical_attributes_history(physical_attributes_history_id)
-);
-
-COMMENT ON TABLE physical_attributes_migration IS 'Provides details of how a migrated physical attribute links to data in NOMIS';
-COMMENT ON COLUMN physical_attributes_migration.offender_book_id IS 'The NOMIS booking number that this data was associated with';
-COMMENT ON COLUMN physical_attributes_migration.attribute_seq IS 'Versioning used in NOMIS to provide a history of edits to the physical attributes for a given booking';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/integration/TestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/integration/TestBase.kt
@@ -24,8 +24,6 @@ abstract class TestBase {
     fun properties(registry: DynamicPropertyRegistry) {
       pgContainer?.run {
         registry.add("spring.datasource.url", pgContainer::getJdbcUrl)
-        registry.add("spring.datasource.username", pgContainer::getUsername)
-        registry.add("spring.datasource.password", pgContainer::getPassword)
         registry.add("spring.flyway.url", pgContainer::getJdbcUrl)
         registry.add("spring.flyway.user", pgContainer::getUsername)
         registry.add("spring.flyway.password", pgContainer::getPassword)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/jpa/repository/RepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/jpa/repository/RepositoryTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonperson.jpa.repository
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlMergeMode
@@ -10,7 +11,7 @@ import uk.gov.justice.digital.hmpps.prisonperson.integration.TestBase
 
 @DataJpaTest
 @Transactional
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureTestDatabase(replace = NONE)
 @SqlMergeMode(MERGE)
 @Sql("classpath:jpa/repository/reset.sql")
 abstract class RepositoryTest : TestBase()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,8 +14,6 @@ api:
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/prison-person-data?sslmode=prefer
-    username: prison-person-data
-    password: prison-person-data
 
   main:
     allow-bean-definition-overriding: true
@@ -33,3 +31,10 @@ hmpps.sqs:
   topics:
     hmppseventtopic:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
+
+database:
+  superuser:
+    username: prison-person-data
+    password: prison-person-data
+  prisonperson:
+    password: prisonperson


### PR DESCRIPTION
Doing this now may help if we end up putting `other person data` and `core person data` into this database and want to use schemas to group the relevant tables.