### PR TITLE
SDIT-1826 Prevent duplicate global tags

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/controller/PhysicalAttributesMigrationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/controller/PhysicalAttributesMigrationController.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.util.SortedSet
 
 @RestController
-@Tag(name = "Physical Attributes", description = "The height and weight of a prisoner")
+@Tag(name = "Physical Attributes")
 @Tag(name = "Migration from NOMIS", description = "Endpoints to facilitate migration of data from NOMIS to the Prison Person database")
 @RequestMapping("/migration/prisoners/{prisonerNumber}/physical-attributes", produces = [MediaType.APPLICATION_JSON_VALUE])
 class PhysicalAttributesMigrationController(private val physicalAttributesMigrationService: PhysicalAttributesMigrationService) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/controller/PhysicalAttributesSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/controller/PhysicalAttributesSyncController.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.prisonperson.service.PhysicalAttributesSyncS
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestController
-@Tag(name = "Physical Attributes", description = "The height and weight of a prisoner")
+@Tag(name = "Physical Attributes")
 @Tag(name = "Sync with NOMIS", description = "Endpoints to keep the Prison Person database in sync with changes in the NOMIS database")
 @RequestMapping("/sync/prisoners/{prisonerNumber}/physical-attributes", produces = [MediaType.APPLICATION_JSON_VALUE])
 class PhysicalAttributesSyncController(private val physicalAttributesSyncService: PhysicalAttributesSyncService) {


### PR DESCRIPTION
Tags with same name but different descriptions both end up in the global tags section - which gets rejected by the openapi generator.

So we need to have only one "Physical Attributes" tag with a description. Currently that is the one found in `PhysicalAttributesController`.