### PR TITLE
CDPS-945: Handling multiple null booking end dates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/config/HmppsPrisonPersonApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/config/HmppsPrisonPersonApiExceptionHandler.kt
@@ -22,7 +22,6 @@ import org.springframework.web.method.annotation.HandlerMethodValidationExceptio
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.multipart.support.MissingServletRequestPartException
 import org.springframework.web.servlet.resource.NoResourceFoundException
-import uk.gov.justice.digital.hmpps.prisonperson.jpa.FieldHistory
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestControllerAdvice
@@ -254,6 +253,6 @@ class HmppsPrisonPersonApiExceptionHandler {
 class PrisonPersonDataNotFoundException(prisonerNumber: String) : Exception("No data for '$prisonerNumber'")
 class ReferenceDataDomainNotFoundException(code: String) : Exception("No data for domain '$code'")
 class ReferenceDataCodeNotFoundException(code: String, domain: String) : Exception("No data for code '$code' in domain '$domain'")
-class IllegalFieldHistoryException(prisonerNumber: String, fieldHistory: FieldHistory) : Exception("Cannot update field history for prisoner: '$prisonerNumber', history id: '${fieldHistory.fieldHistoryId}'")
+class IllegalFieldHistoryException(prisonerNumber: String) : Exception("Cannot update field history for prisoner: '$prisonerNumber'")
 
 class DownstreamServiceException(message: String, cause: Throwable) : Exception(message, cause)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/jpa/WithFieldHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/jpa/WithFieldHistory.kt
@@ -58,10 +58,10 @@ abstract class WithFieldHistory<T : AbstractAggregateRoot<T>?> : AbstractAggrega
           previousVersion
             ?.takeIf { it.appliesTo == null }
             ?.let {
-              it.appliesTo = appliesFrom
+              it.appliesTo = if (appliesFrom > it.appliesFrom) appliesFrom else lastModifiedAt
 
               // If the resulting update to appliesTo causes it to be less than appliesFrom, throw exception:
-              if (it.appliesFrom > it.appliesTo) throw IllegalFieldHistoryException(prisonerNumber, it)
+              if (it.appliesFrom > it.appliesTo) throw IllegalFieldHistoryException(prisonerNumber)
             }
 
           fieldHistory.add(


### PR DESCRIPTION
This helps to reduce the chance that we end up with illogical from-to dates by using the `lastModifiedAt` timestamp as an alternative point to set as a `appliesTo` boundary.  