### PR TITLE
CDPS-979: Enabling wider use of domain events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/config/HmppsPrisonPersonApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/config/HmppsPrisonPersonApiExceptionHandler.kt
@@ -22,6 +22,7 @@ import org.springframework.web.method.annotation.HandlerMethodValidationExceptio
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.multipart.support.MissingServletRequestPartException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.prisonperson.enums.EventType
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestControllerAdvice
@@ -267,5 +268,5 @@ class ReferenceDataDomainNotFoundException(code: String) : Exception("No data fo
 class ReferenceDataCodeNotFoundException(code: String, domain: String) : Exception("No data for code '$code' in domain '$domain'")
 class GenericNotFoundException(message: String) : Exception(message)
 class IllegalFieldHistoryException(prisonerNumber: String) : Exception("Cannot update field history for prisoner: '$prisonerNumber'")
-
+class EventHandlerException(eventType: EventType) : Exception("Cannot handle event of type: '${eventType.name}'")
 class DownstreamServiceException(message: String, cause: Throwable) : Exception(message, cause)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/jpa/PhysicalAttributes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/jpa/PhysicalAttributes.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.prisonperson.enums.PrisonPersonField.WEIGHT
 import uk.gov.justice.digital.hmpps.prisonperson.enums.Source
 import uk.gov.justice.digital.hmpps.prisonperson.enums.Source.DPS
 import uk.gov.justice.digital.hmpps.prisonperson.mapper.toSimpleDto
-import uk.gov.justice.digital.hmpps.prisonperson.service.event.publish.PhysicalAttributesUpdatedEvent
+import uk.gov.justice.digital.hmpps.prisonperson.service.event.PhysicalAttributesUpdatedEvent
 import java.time.ZonedDateTime
 import java.util.SortedSet
 import kotlin.reflect.KMutableProperty0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/EventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/EventService.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.prisonperson.service.event
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT
+import org.springframework.transaction.event.TransactionalEventListener
+import uk.gov.justice.digital.hmpps.prisonperson.service.event.handlers.EventHandlerFactory
+
+@Service
+class EventService(private val eventHandlerFactory: EventHandlerFactory) {
+  @TransactionalEventListener(phase = AFTER_COMMIT)
+  fun handleEvent(event: PrisonPersonEvent) {
+    eventHandlerFactory.getHandler(event.type).handleEvent(event)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/PrisonPersonEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/PrisonPersonEvent.kt
@@ -1,11 +1,9 @@
-package uk.gov.justice.digital.hmpps.prisonperson.service.event.publish
+package uk.gov.justice.digital.hmpps.prisonperson.service.event
 
 import uk.gov.justice.digital.hmpps.prisonperson.enums.EventType
 import uk.gov.justice.digital.hmpps.prisonperson.enums.EventType.PHYSICAL_ATTRIBUTES_UPDATED
 import uk.gov.justice.digital.hmpps.prisonperson.enums.PrisonPersonField
 import uk.gov.justice.digital.hmpps.prisonperson.enums.Source
-import uk.gov.justice.digital.hmpps.prisonperson.service.event.DomainEvent
-import uk.gov.justice.digital.hmpps.prisonperson.service.event.PrisonPersonAdditionalInformation
 import java.time.ZonedDateTime
 
 abstract class PrisonPersonEvent(val type: EventType) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/handlers/EventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/handlers/EventHandler.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.prisonperson.service.event.handlers
+
+import uk.gov.justice.digital.hmpps.prisonperson.enums.EventType
+import uk.gov.justice.digital.hmpps.prisonperson.service.event.PrisonPersonEvent
+
+interface EventHandler {
+  fun handleEvent(event: PrisonPersonEvent)
+  fun getType(): EventType
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/handlers/EventHandlerFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/handlers/EventHandlerFactory.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.prisonperson.service.event.handlers
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.prisonperson.config.EventHandlerException
+import uk.gov.justice.digital.hmpps.prisonperson.enums.EventType
+import java.util.EnumMap
+
+@Component
+class EventHandlerFactory(handlers: Collection<EventHandler>) {
+  private val handlers: EnumMap<EventType, EventHandler> = if (handlers.isEmpty()) {
+    EnumMap(EventType::class.java)
+  } else {
+    EnumMap(handlers.associateBy { it.getType() })
+  }
+
+  fun getHandler(eventType: EventType): EventHandler = handlers[eventType] ?: throw EventHandlerException(eventType)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/handlers/PhysicalAttributesUpdatedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/handlers/PhysicalAttributesUpdatedHandler.kt
@@ -1,21 +1,24 @@
-package uk.gov.justice.digital.hmpps.prisonperson.service.event.publish
+package uk.gov.justice.digital.hmpps.prisonperson.service.event.handlers
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Service
-import org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT
-import org.springframework.transaction.event.TransactionalEventListener
+import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.prisonperson.config.EventProperties
+import uk.gov.justice.digital.hmpps.prisonperson.enums.EventType
+import uk.gov.justice.digital.hmpps.prisonperson.service.event.PrisonPersonEvent
+import uk.gov.justice.digital.hmpps.prisonperson.service.event.publish.DomainEventPublisher
 
-@Service
-class EventService(
+@Component
+class PhysicalAttributesUpdatedHandler(
   private val eventProperties: EventProperties,
   private val telemetryClient: TelemetryClient,
   private val domainEventPublisher: DomainEventPublisher,
-) {
-  @TransactionalEventListener(phase = AFTER_COMMIT)
-  fun handleEvent(event: PrisonPersonEvent) {
+) : EventHandler {
+
+  override fun getType() = EventType.PHYSICAL_ATTRIBUTES_UPDATED
+
+  override fun handleEvent(event: PrisonPersonEvent) {
     log.info(event.toString())
 
     event.toDomainEvent(eventProperties.baseUrl).run {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/PhysicalAttributesUpdatedHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/PhysicalAttributesUpdatedHandlerTest.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.prisonperson.service.event
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.prisonperson.config.EventProperties
+import uk.gov.justice.digital.hmpps.prisonperson.enums.EventType.PHYSICAL_ATTRIBUTES_UPDATED
+import uk.gov.justice.digital.hmpps.prisonperson.enums.PrisonPersonField.HEIGHT
+import uk.gov.justice.digital.hmpps.prisonperson.enums.PrisonPersonField.WEIGHT
+import uk.gov.justice.digital.hmpps.prisonperson.enums.Source.DPS
+import uk.gov.justice.digital.hmpps.prisonperson.service.event.handlers.PhysicalAttributesUpdatedHandler
+import uk.gov.justice.digital.hmpps.prisonperson.service.event.publish.DomainEventPublisher
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class PhysicalAttributesUpdatedHandlerTest {
+
+  private val telemetryClient = mock<TelemetryClient>()
+  private val domainEventPublisher = mock<DomainEventPublisher>()
+  private val baseUrl = "http://localhost:8080"
+
+  @Test
+  fun `handle event - publish enabled`() {
+    val eventProperties = EventProperties(publish = true, baseUrl = baseUrl)
+    val handler = PhysicalAttributesUpdatedHandler(eventProperties, telemetryClient, domainEventPublisher)
+    val event = PhysicalAttributesUpdatedEvent(PRISONER_NUMBER, NOW, DPS, listOf(HEIGHT, WEIGHT))
+
+    handler.handleEvent(event)
+
+    val domainEventCaptor = argumentCaptor<DomainEvent<*>>()
+    verify(domainEventPublisher).publish(domainEventCaptor.capture())
+    assertThat(domainEventCaptor.firstValue).isEqualTo(
+      DomainEvent(
+        eventType = PHYSICAL_ATTRIBUTES_UPDATED.domainEventType,
+        additionalInformation = PrisonPersonAdditionalInformation(
+          url = "$baseUrl/prisoners/$PRISONER_NUMBER",
+          source = event.source,
+          prisonerNumber = PRISONER_NUMBER,
+          fields = listOf(HEIGHT, WEIGHT),
+        ),
+        description = PHYSICAL_ATTRIBUTES_UPDATED.description,
+        occurredAt = NOW,
+      ),
+    )
+  }
+
+  @Test
+  fun `handle event - publish disabled`() {
+    val eventProperties = EventProperties(publish = false, baseUrl = baseUrl)
+    val handler = PhysicalAttributesUpdatedHandler(eventProperties, telemetryClient, domainEventPublisher)
+    val event = PhysicalAttributesUpdatedEvent(PRISONER_NUMBER, NOW, DPS, listOf(HEIGHT, WEIGHT))
+
+    handler.handleEvent(event)
+
+    verify(domainEventPublisher, never()).publish(any<DomainEvent<*>>())
+  }
+
+  private companion object {
+    const val PRISONER_NUMBER = "A1234AA"
+
+    val NOW: ZonedDateTime = ZonedDateTime.ofInstant(Instant.now(), ZoneId.of("Europe/London"))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/handlers/EventHandlerFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/event/handlers/EventHandlerFactoryTest.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.prisonperson.service.event.handlers
+
+import io.mockk.clearAllMocks
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.prisonperson.config.EventHandlerException
+import uk.gov.justice.digital.hmpps.prisonperson.enums.EventType
+
+class EventHandlerFactoryTest {
+  private val eventHandler = mock<EventHandler>()
+
+  @AfterEach
+  fun tearDown() {
+    clearAllMocks()
+  }
+
+  @Test
+  fun `event handler factory provides expected handler`() {
+    whenever(eventHandler.getType()).thenReturn(EVENT_TYPE)
+    val eventHandlerFactory = EventHandlerFactory(listOf(eventHandler))
+
+    assertThat(eventHandlerFactory.getHandler(EVENT_TYPE)).isEqualTo(eventHandler)
+  }
+
+  @Test
+  fun `event handler factory throws when handler not available for event type`() {
+    val eventHandlerFactory = EventHandlerFactory(emptyList())
+
+    assertThatThrownBy { eventHandlerFactory.getHandler(EVENT_TYPE) }
+      .isInstanceOf(EventHandlerException::class.java)
+      .hasMessage("Cannot handle event of type: 'PHYSICAL_ATTRIBUTES_UPDATED'")
+  }
+
+  private companion object {
+    val EVENT_TYPE = EventType.PHYSICAL_ATTRIBUTES_UPDATED
+  }
+}


### PR DESCRIPTION
Currently we only use this pattern for publishing events onto the hmpps domain events topic.

This domain events pattern (utilising the AbstractAggregateRoot class) ensures that we don't publish events if the transaction fails and is rolled back.

A great article explaining it is [here](https://dev.to/kirekov/spring-data-power-of-domain-events-2okm).

This refactor PR enables us to make wider usage of it (for instance we could ensure that we don't fire telemetry events if the transaction is rolled back).