### PR TITLE
CDPS-956: Update document type for distinguishing mark images.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/client/documentservice/dto/DocumentSearchRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/client/documentservice/dto/DocumentSearchRequestDto.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonperson.client.documentservice.dto
 
 enum class DocumentType {
   PRISONER_PROFILE_PICTURE,
-  PHYSICAL_IDENTIFIER_PICTURE,
+  DISTINGUISHING_MARK_IMAGE,
 }
 
 enum class OrderBy {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/IdentifyingMarksService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/IdentifyingMarksService.kt
@@ -64,7 +64,7 @@ class IdentifyingMarksService(
       val uploadedDocument = documentServiceClient.putDocument(
         document = file.bytes,
         filename = file.originalFilename,
-        documentType = DocumentType.PHYSICAL_IDENTIFIER_PICTURE,
+        documentType = DocumentType.DISTINGUISHING_MARK_IMAGE,
         meta = mapOf("prisonerNumber" to identifyingMarkRequest.prisonerNumber),
         fileType,
         documentRequestContext = DocumentRequestContext(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/controller/IdentifyingMarksControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/controller/IdentifyingMarksControllerIntTest.kt
@@ -149,7 +149,7 @@ class IdentifyingMarksControllerIntTest : IntegrationTestBase() {
 
         documentService.stubPostNewDocument(
           uuid = docUuid.toString(),
-          documentType = DocumentType.PHYSICAL_IDENTIFIER_PICTURE,
+          documentType = DocumentType.DISTINGUISHING_MARK_IMAGE,
           result = DOCUMENT_DTO,
         )
 
@@ -265,7 +265,7 @@ class IdentifyingMarksControllerIntTest : IntegrationTestBase() {
   private companion object {
     val DOCUMENT_DTO = DocumentDto(
       documentUuid = "c46d0ce9-e586-4fa6-ae76-52ea8c242260",
-      documentType = DocumentType.PHYSICAL_IDENTIFIER_PICTURE,
+      documentType = DocumentType.DISTINGUISHING_MARK_IMAGE,
       documentFilename = "fileName",
       filename = "fileName",
       fileExtension = "jpg",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/IdentifyingMarksServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonperson/service/IdentifyingMarksServiceTest.kt
@@ -167,7 +167,7 @@ class IdentifyingMarksServiceTest {
 
       val documentDto = DocumentDto(
         documentUuid = "c46d0ce9-e586-4fa6-ae76-52ea8c242260",
-        documentType = DocumentType.PHYSICAL_IDENTIFIER_PICTURE,
+        documentType = DocumentType.DISTINGUISHING_MARK_IMAGE,
         documentFilename = "fileName.jpg",
         filename = "fileName",
         fileExtension = "jpg",
@@ -185,7 +185,7 @@ class IdentifyingMarksServiceTest {
       whenever(referenceDataCodeRepository.findById("MARK_TYPE_SCAR")).thenReturn(Optional.of(SCAR_REFERENCE))
       whenever(referenceDataCodeRepository.findById("SIDE_L")).thenReturn(Optional.of(LEFT_SIDE_REFERENCE))
       whenever(referenceDataCodeRepository.findById("PART_ORIENT_CENTR")).thenReturn(Optional.of(CENTRE_REFERENCE))
-      whenever(documentServiceClient.putDocument(file.bytes, "fileName.jpg", DocumentType.PHYSICAL_IDENTIFIER_PICTURE, mapOf("prisonerNumber" to "A1234AA"), fileType, DOCUMENT_REQ_CONTEXT)).thenReturn(documentDto)
+      whenever(documentServiceClient.putDocument(file.bytes, "fileName.jpg", DocumentType.DISTINGUISHING_MARK_IMAGE, mapOf("prisonerNumber" to "A1234AA"), fileType, DOCUMENT_REQ_CONTEXT)).thenReturn(documentDto)
 
       val identifyingMarkRequest = IdentifyingMarkRequest(
         prisonerNumber = PRISONER_NUMBER,
@@ -250,7 +250,7 @@ class IdentifyingMarksServiceTest {
       whenever(referenceDataCodeRepository.findById("MARK_TYPE_SCAR")).thenReturn(Optional.of(SCAR_REFERENCE))
       whenever(referenceDataCodeRepository.findById("SIDE_L")).thenReturn(Optional.of(LEFT_SIDE_REFERENCE))
       whenever(referenceDataCodeRepository.findById("PART_ORIENT_CENTR")).thenReturn(Optional.of(CENTRE_REFERENCE))
-      whenever(documentServiceClient.putDocument(file.bytes, "fileName.jpg", DocumentType.PHYSICAL_IDENTIFIER_PICTURE, mapOf("prisonerNumber" to "A1234AA"), fileType, DOCUMENT_REQ_CONTEXT)).thenThrow(RuntimeException("Put document request failed"))
+      whenever(documentServiceClient.putDocument(file.bytes, "fileName.jpg", DocumentType.DISTINGUISHING_MARK_IMAGE, mapOf("prisonerNumber" to "A1234AA"), fileType, DOCUMENT_REQ_CONTEXT)).thenThrow(RuntimeException("Put document request failed"))
 
       val identifyingMarkRequest = IdentifyingMarkRequest(
         prisonerNumber = PRISONER_NUMBER,


### PR DESCRIPTION
- [x] Updated references to the `PHYSICAL_IDENTIFIER_PICTURE` document type to `DISTINGUISHING_MARK_IMAGE` to align with changing being made in the document management service (PR [here](https://github.com/ministryofjustice/hmpps-document-management-api/pull/86/files)).